### PR TITLE
Major changes to BaseParser

### DIFF
--- a/docs/source/contributor-guide.rst
+++ b/docs/source/contributor-guide.rst
@@ -61,12 +61,12 @@ We also have a recommendations for the parser behavior:
 Implementing ``group``
 ----------------------
 
-The ``group`` operation finds all sets of files in a user-provided list that should be parsed together.
-Implementing ``group`` is optional.
-The default implementation is to return each file in the directory as its own group.
+The ``group`` operation finds all sets of files in a user-provided of paths list that should be parsed together.
+By default, ``group`` returns each file in the paths and any files in the directories passed to ``group`` as their own set.
+Implementing ``group`` is optional and all implementations must perform recursion into all subdirectories provided to ``group``.
 
 Files are allowed to appear in more than one group,
-but we recommend generating only the largest valid group of files to minimize the same metadata being parsed multiple times.
+but we recommend generating only the largest valid group of files to minimize the same metadata being generated multiple times.
 
 It is important to note that that file groups are specific to a parser.
 Groupings of files that are meaningful to one parser need not be meaningful to another.

--- a/docs/source/contributor-guide.rst
+++ b/docs/source/contributor-guide.rst
@@ -61,12 +61,12 @@ We also have a recommendations for the parser behavior:
 Implementing ``group``
 ----------------------
 
-The ``group`` operation finds all groups of files in a directory that should be parsed together.
+The ``group`` operation finds all sets of files in a user-provided list that should be parsed together.
 Implementing ``group`` is optional.
 The default implementation is to return each file in the directory as its own group.
 
 Files are allowed to appear in more than one group,
-and we recommend generating all possible groupings of files when in doubt.
+but we recommend generating only the largest valid group of files to minimize the same metadata being parsed multiple times.
 
 It is important to note that that file groups are specific to a parser.
 Groupings of files that are meaningful to one parser need not be meaningful to another.

--- a/docs/source/contributor-guide.rst
+++ b/docs/source/contributor-guide.rst
@@ -11,6 +11,10 @@ If you are new to MaterailsIO, we recommend reviewing the `User Guide <user-guid
 Minimally, you need only implement the ``parse``, ``version``, and ``implementors`` operations for a new parser.
 Each of these methods (and any other methods you override) must be stateless, so that running the operation does not change the behavior of the parser.
 
+We also have subclasses of ``BaseParser`` that are useful for common types of parsers:
+
+- ``BaseSingleFileParser``: Parsers that only ever evaluate a single file at a time
+
 Class Attributes and Initializer
 --------------------------------
 
@@ -43,7 +47,7 @@ We do not specify any particular schema for the output but we do recommend best 
     Deviating from already existing formats complicates modifications to a parser.
 
 
-Beyond recommendations about the data type, we have a recommendations for the parser behavior:
+We also have a recommendations for the parser behavior:
 
 #. *Avoid configuration options that change only output format*
     Parsers can take configuration options that alter the output format, but configurations should be used sparingly.
@@ -57,15 +61,20 @@ Beyond recommendations about the data type, we have a recommendations for the pa
 Implementing ``group``
 ----------------------
 
-The ``group`` operation finds all groups of files in a directly that should be treated as related units.
+The ``group`` operation finds all groups of files in a directory that should be parsed together.
 Implementing ``group`` is optional.
 The default implementation is to return each file in the directory as its own group.
-New implementations of ``group`` need not return every file as part of a group (e.g., it can perform compatibility filtering)
-and files are allowed to appear in more than 1 group.
-In general, our recommendation is to return all possible groupings of files when in doubt.
+
+Files are allowed to appear in more than one group,
+and we recommend generating all possible groupings of files when in doubt.
+
+It is important to note that that file groups are specific to a parser.
+Groupings of files that are meaningful to one parser need not be meaningful to another.
+For that reason, limit the definition of groups to sets of files that can be parsed together
+without consideration to what other information makes the files related (e.g., being in the same directory).
 
 Another appropriate use of the ``group`` operation is to filter out files which are very unlikely to parse correctly.
-For example, a PDF parser could identify only parsers with the correct file extensions.
+For example, a PDF parser could identify only files with a ".pdf" extension.
 
 Implementing ``citations`` and ``implementors``
 -----------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,3 @@
-.. MaterialsIO documentation master file, created by
-   sphinx-quickstart on Tue Mar 19 10:49:01 2019.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Welcome to MaterialsIO's documentation!
 =======================================
 

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -19,14 +19,14 @@ Both parsers that are part of the MaterialsIO base package will be installed,
 Example Usage
 ~~~~~~~~~~~~~
 
-As an example, we illustrate the use of ``GenericFileParser``, a parser that returns status information about a file::
+As an example, we illustrate the use of ``GenericFileParser``, a parser that returns basic status and type information about a file::
 
     parser = GenericFileParser()
     parser.parse(['setup.py'])
 
 
 The above snippet creates the parser object and runs it on a file named ``setup.py``.
-Run in the root directory of the MaterialsIO it would produce output similar to:
+Run in the root directory of the MaterialsIO, it would produce output similar to:
 
 .. code:: json
 
@@ -38,7 +38,7 @@ Run in the root directory of the MaterialsIO it would produce output similar to:
     }]
 
 
-The ``parse`` operation evaluates a file or group of files that describe a single object (e.g., a simulation).
+The ``parse`` operation generates a single summary from a file or, in advanced cases, a group of files that describe the same object (e.g., a simulation).
 Running on the parser on every file in a directory is accomplished by the ``group`` method::
 
     metadata = [parser.parse(x) for x in parser.group('.')]
@@ -51,15 +51,13 @@ For convenience, we provide a utility operation to parse all the files in a dire
 
     metadata = list(parser.parse_directory('.'))
 
-``parse_directory`` is a generator function, so we use `list` to turn the output into a list format.
+``parse_directory`` is a generator function, so we use ``list`` to turn the output into a list format.
 
 .. todo:: We need an example parser to evaluate grouping functionality
 
 
-Available Methods
-~~~~~~~~~~~~~~~~~
-
-.. todo:: Is having two separate descriptions helpful?
+Parser Interface
+~~~~~~~~~~~~~~~~
 
 The functionality of a parser is broken into several simple operations.
 
@@ -74,18 +72,28 @@ Most parsers do not have any options for the initializer, so you can create them
 Some parsers require configuration options that define how the parser runs,
 such as the location of a non-Python executable.
 
-Parsing Methods
----------------
+Parsing Method
+--------------
 
 The main operation for any parser is the data extraction operation: ``parse``.
-The ``parse`` operation takes a list of paths to files that collectively describe the same object (e.g., an experiment),
-and returns a summary of the data the files hold::
 
-    metadata = parser.parse_files(['/my/file1', '/my/file2'])
+In most cases, the ``parse`` operation takes the path to a file and
+and returns a summary of the data the file holds::
 
-In some cases, you can provide information that is not contained within the file themselves, which can be provided to the parser as a "context"::
+    metadata = parser.parse_files(['/my/file'])
+
+Some parsers take multiple files that describe the same object (e.g., the input and output files of a simulation)
+and use them to generate a single metadata record::
+
+    metadata = parser.parse_files(['/my/file.in', '/my/file.out'])
+
+The `grouping method <#grouping-files>`_ for these parsers provides logic to identify groups of related files.
+
+Some parsers also can use information that is not contained within the file themselves, which can be provided to the parser as a "context"::
 
     metadata = parser.parse_files(['/my/file1'], context={'headers': {'temp': 'temperature'}})
+
+The documentation for the parser should indicate valid types of context information.
 
 Grouping Files
 --------------
@@ -104,8 +112,8 @@ Two functions, ``citations`` and ``implementors``, are available to determine wh
 in scientific articles.
 
 
-Parser API
-----------
+Full Parser API
+---------------
 
 The full API for the parsers are described as a Python abstract class:
 

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -39,13 +39,13 @@ Run in the root directory of the MaterialsIO, it would produce output similar to
 
 
 The ``parse`` operation generates a single summary from a file or, in advanced cases, a group of files that describe the same object (e.g., a simulation).
-Running on the parser on every file in a directory is accomplished by the ``group`` method::
+The ``group`` operation identifies these sets of files files::
 
-    metadata = [parser.parse(x) for x in parser.group('.')]
+    metadata = [parser.parse(x) for x in parser.group(['setup.py', 'requirements.txt'])]
 
-The ``group`` operation generates a list of files in a certain directory that are likely to be compatible with a parser.
-Further, some implementations of ``group`` identify groupings of files that describe the same object (e.g., the input and output files of the same simulation).
-Both filtering files and grouping are unnecessary for ``FileParser``, which treats each file individually and works on any kind of file.
+The ``group`` operation for ``GenericFileParser`` places each file in its own group, because they are all treated separately.
+More advanced parsers identify groupings of files that describe the same object (e.g., the input and output files of the same simulation),
+and may only generate groups from files that are likely to be compatible with the parser.
 
 For convenience, we provide a utility operation to parse all the files in a directory::
 

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -38,29 +38,20 @@ Run in the root directory of the MaterialsIO it would produce output similar to:
     }]
 
 
-The ``parse`` operation evaluates a file or group of files that describe a single logical object (e.g., a simulation).
+The ``parse`` operation evaluates a file or group of files that describe a single object (e.g., a simulation).
 Running on the parser on every file in a directory is accomplished by the ``group`` method::
 
     metadata = [parser.parse(x) for x in parser.group('.')]
 
-The ``group`` operation evaluates every file in the listed directory and its subdirectories,
-and generates groupings of files that likely describe the same object.
-Grouping is unnecessary for ``FileParser``, which treats each file individually.
-Grouping is necessary in cases where an object is described by multiple objects (e.g., the inputs and output files for a simulation).
+The ``group`` operation generates a list of files in a certain directory that are likely to be compatible with a parser.
+Further, some implementations of ``group`` identify groupings of files that describe the same object (e.g., the input and output files of the same simulation).
+Both filtering files and grouping are unnecessary for ``FileParser``, which treats each file individually and works on any kind of file.
 
-
-Another potential problem with the script about is that some files may not be compatible with the parser.
-The MaterialsIO parsers provide a ``is_valid`` operation that determines whether a specific grouping of
-files is actually compatible with a parser::
-
-    metadata = [parser.parse(x) for x in parser.group('.') if parser.is_valid(x)]
-
-The above function returns a list of all metadata that is possible to extract from a directory.
 For convenience, we provide a utility operation to parse all the files in a directory::
 
     metadata = list(parser.parse_directory('.'))
 
-`parse_directory` is a generator function, so we use `list` to turn the output into a list format.
+``parse_directory`` is a generator function, so we use `list` to turn the output into a list format.
 
 .. todo:: We need an example parser to evaluate grouping functionality
 
@@ -103,15 +94,6 @@ Parsers also provide the ability to quickly find groups of associated files: ``g
 The ``group`` operation takes a directory as input and generates candidate groups of files::
 
     parser.group('/data/directory')
-
-Compatibility Checking
-----------------------
-
-Parsers also provide a method for checking whether a group of files is compatible with it:: `is_valid`.
-These ``is_valid`` method take a list of the files in a certain group as input and, optionally,
-context information about the files::
-
-    parser.is_valid(['/my/file'])
 
 Attribution Functions
 ---------------------

--- a/materials_io/base.py
+++ b/materials_io/base.py
@@ -1,4 +1,4 @@
-from typing import List, Iterator, Tuple, Iterable
+from typing import List, Iterator, Tuple, Iterable, Union
 from abc import ABC, abstractmethod
 from mdf_toolbox import dict_merge
 import logging
@@ -32,20 +32,19 @@ class BaseParser(ABC):
             path (str): Root of directory to parser
             context (dict): Context about the files
         Yields:
-            ([str], dict): Tuple of the group identity and the string
+            ([str], dict): Tuple of the group identity and the metadata unit
         """
-
-        # Iterate over all directories
-        for root, dirs, files in os.walk(path):
-            # Generate the full paths for all of the contents
-            full_paths = map(lambda x: os.path.join(root, x), files + dirs)
-
-            # Parse each identified group
-            for group in self.group(full_paths, context):
-                yield (group, self.parse(group, context))
+        # Parse each identified group
+        for group in self.group(path, context):
+            try:
+                metadata_unit = self.parse(group, context)
+            except Exception:
+                continue
+            else:
+                yield (group, metadata_unit)
 
     @abstractmethod
-    def parse(self, group: List[str], context: dict = None) -> dict:
+    def parse(self, group: Iterable[str], context: dict = None) -> dict:
         """Extract metadata from a group of files
 
         A group of files is a set of 1 or more files that describe the same object, and will be
@@ -59,41 +58,55 @@ class BaseParser(ABC):
             (dict): The parsed results, in JSON-serializable format.
         """
 
-    def parse_as_unit(self, files: List[str]) -> dict:
+    def parse_as_unit(self, files: Union[str, Iterable[str]], context: dict = None) -> dict:
         """Parse a group of files and merge their metadata
 
         Used if each file in a group are parsed separately, but the resultant metadata
         should be combined after parsing.
 
         Args:
-            files ([str]): List of files to parse
+            files (str or [str]): Path(s) to parse
+            context (dict): Context about the files
         Returns:
-            (dict): Metadata summary from
+            (dict): Metadata summary from the files
         """
-
         # Initialize output dictionary
         metadata = {}
 
         # Loop over all files
-        for group in self.group(files):
+        for group in self.group(files, context):
             try:
-                record = self.parse(group)
+                record = self.parse(group, context)
             except Exception:
                 continue
-            metadata = dict_merge(metadata, record)
+            else:
+                metadata = dict_merge(metadata, record, append_lists=True)
         return metadata
 
-    def group(self, files: Iterable[str], context: dict = None) -> Iterator[Tuple[str, ...]]:
+    def group(self, files: Union[str, Iterable[str]],
+              context: dict = None) -> Iterator[Tuple[str, ...]]:
         """Identify a groups of files that should be parsed together
 
         Args:
-            files ([str]): List of paths, which could include both files and directories
+            files (str or [str]): Path(s), which could include both files and directories
             context (dict): Context about the files
         Yields:
             ((str)): Groups of files
         """
+        if isinstance(files, str):
+            files = [files]
+        # Clean paths
+        files = [os.path.abspath(os.path.expanduser(f)) for f in files]
 
-        return zip(f for f in files if not os.path.isdir(f))
+        # Default: Every file is in its own group, skipping symlinks
+        for fn in files:
+            if os.path.isfile(fn):
+                yield (fn,)
+            # Recurse through directories (could also be done with os.walk(), especially
+            # for groups that may span directories)
+            elif os.path.isdir(fn):
+                for f in os.listdir(fn):
+                    yield from self.group(os.path.join(fn, f))
 
     def citations(self) -> List[str]:
         """Citation(s) and reference(s) for this parser
@@ -138,7 +151,7 @@ class BaseSingleFileParser(BaseParser):
     Instead of implementing :meth:`parse`, implement :meth:`_parse_file`"""
 
     @abstractmethod
-    def _parse_file(self, path, context=None):
+    def _parse_file(self, path: str, context=None):
         """Generate the metadata for a single file
 
         Args:
@@ -148,7 +161,7 @@ class BaseSingleFileParser(BaseParser):
             (dict): Metadata for the file
         """
 
-    def parse(self, group, context=None):
+    def parse(self, group: Union[str, Iterable[str]], context=None):
         # Error catching: allows for single files to passed not as list
         if isinstance(group, str):
             return self._parse_file(group, context)

--- a/materials_io/base.py
+++ b/materials_io/base.py
@@ -66,7 +66,7 @@ class BaseParser(ABC):
         return metadata
 
     @abstractmethod
-    def parse(self, group, context=None):
+    def parse(self, group, context=None) -> dict:
         """Extract metadata from a group of files
 
         A group of files is a set of 1 or more files that describe the same object, and will be
@@ -85,7 +85,7 @@ class BaseParser(ABC):
 
         Args:
             root (str): Path to a directory
-            context (dict): An optional data context/configuration dictionary. 
+            context (dict): An optional data context/configuration dictionary.
         Yields:
             ((str)): Groups of files
         """
@@ -116,7 +116,7 @@ class BaseParser(ABC):
         """
 
     @abstractmethod
-    def version(self):
+    def version(self) -> str:
         """Return the version of the parser
 
         Returns:
@@ -142,9 +142,18 @@ class BaseSingleFileParser(BaseParser):
 
         Args:
             path (str): Path to the file
-            context (dict):
+            context (dict): Optional context information about the file
+        Returns:
+            (dict): Metadata for the file
         """
-        pass
 
     def parse(self, group, context=None):
-        return [self._parse_file(f, context) for f in group]
+        # Error catching: allows for single files to passed not as list
+        if isinstance(group, str):
+            return self._parse_file(group, context)
+
+        # Assumes that the group must have exactly one file
+        if len(group) > 1:
+            raise ValueError('Parser only takes a single file at a time')
+
+        return self._parse_file(group[0], context)

--- a/materials_io/base.py
+++ b/materials_io/base.py
@@ -134,8 +134,7 @@ class BaseSingleFileParser(BaseParser):
                 record = self.parse(f)
             except Exception:
                 continue
-            else:
-                metadata = dict_merge(metadata, record)
+            metadata = dict_merge(metadata, record)
         return metadata
 
     @abstractmethod

--- a/materials_io/base.py
+++ b/materials_io/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from mdf_toolbox import dict_merge
 import logging
 import os
 
@@ -16,7 +17,9 @@ class BaseParser(ABC):
     :meth:`citations` can be used if there are papers that should be cited if the parser is used
     as part of a scientific publication.
 
-    See documentation for further details: TBD.
+    See `MaterialsIO Contributor Guide
+    <https://materialsio.readthedocs.io/en/latest/contributor-guide.html>`_
+    for further details.
     """
 
     def parse_directory(self, path, context=None):
@@ -38,16 +41,41 @@ class BaseParser(ABC):
             except Exception:
                 continue
 
+    def parse_as_unit(self, files):
+        """Parse a group of files and merge their metadata
+
+        Used if each file in a group must be parsed separately, but should still only produce one
+        record. For example, if a directory contains separate files from
+        different imaging techniques.
+
+        Args:
+            files ([str]): List of files to parse
+        Returns:
+            (dict): Metadata summary from
+        """
+
+        metadata = {}
+
+        # TODO (lw): @jgaff Do we need grouping functionality, or just loop over each file?
+        for f in files:
+            try:
+                record = self.parse(f)
+            except Exception:
+                continue
+            else:
+                metadata = dict_merge(metadata, record)
+        return metadata
+
     @abstractmethod
     def parse(self, group, context=None):
         """Extract metadata from a group of files
 
         Arguments:
-            group (list of str):  A list of one or more files that describe the same object
+            group (list of str):  A list of one or more files that should be parsed together
             context (dict): An optional data context/configuration dictionary. Default None.
 
         Returns:
-            (list of dict): The parsed results, in JSON-serializable format.
+            (dict): The parsed results, in JSON-serializable format.
         """
         pass
 

--- a/materials_io/base.py
+++ b/materials_io/base.py
@@ -83,23 +83,27 @@ class BaseParser(ABC):
                 metadata = dict_merge(metadata, record, append_lists=True)
         return metadata
 
-    def group(self, files: Union[str, Iterable[str]],
+    def group(self, paths: Union[str, Iterable[str]],
               context: dict = None) -> Iterator[Tuple[str, ...]]:
         """Identify a groups of files that should be parsed together
 
+        Will create groups using the files provided in ``paths``,
+         and any files contained within the directories of the directories provided to ``paths``
+         and subdirectories of those directories.
+
         Args:
-            files (str or [str]): Path(s), which could include both files and directories
+            paths (str or [str]): Path available for grouping, which could include both files and directories
             context (dict): Context about the files
         Yields:
             ((str)): Groups of files
         """
-        if isinstance(files, str):
-            files = [files]
+        if isinstance(paths, str):
+            paths = [paths]
         # Clean paths
-        files = [os.path.abspath(os.path.expanduser(f)) for f in files]
+        paths = [os.path.abspath(os.path.expanduser(f)) for f in paths]
 
         # Default: Every file is in its own group, skipping symlinks
-        for fn in files:
+        for fn in paths:
             if os.path.isfile(fn):
                 yield (fn,)
             # Recurse through directories (could also be done with os.walk(), especially

--- a/materials_io/base.py
+++ b/materials_io/base.py
@@ -41,30 +41,6 @@ class BaseParser(ABC):
             except Exception:
                 continue
 
-    def parse_as_unit(self, files):
-        """Parse a group of files and merge their metadata
-
-        Used if each file in a group are parsed separately, but the resultant metadata
-        should be combined after parsing.
-
-        Args:
-            files ([str]): List of files to parse
-        Returns:
-            (dict): Metadata summary from
-        """
-
-        metadata = {}
-
-        # TODO (lw): @jgaff Do we need grouping functionality, or just loop over each file?
-        for f in files:
-            try:
-                record = self.parse(f)
-            except Exception:
-                continue
-            else:
-                metadata = dict_merge(metadata, record)
-        return metadata
-
     @abstractmethod
     def parse(self, group, context=None) -> dict:
         """Extract metadata from a group of files
@@ -135,6 +111,32 @@ class BaseSingleFileParser(BaseParser):
     """Base class for parsers that only ever considers a single file at a time
 
     Instead of implementing :meth:`parse`, implement :meth:`_parse_file`"""
+
+    def parse_as_unit(self, files):
+        """Parse a group of files and merge their metadata
+
+        Used if each file in a group are parsed separately, but the resultant metadata
+        should be combined after parsing.
+
+        Args:
+            files ([str]): List of files to parse
+        Returns:
+            (dict): Metadata summary from
+        """
+
+        metadata = {}
+
+        # TODO (lw): Decide whether this needs to work with parsers that operate on groups of files
+        #  At present, I do not yet see why you can just use the `parse` method for parsers that
+        #  operate on groups and return a single metadata record
+        for f in files:
+            try:
+                record = self.parse(f)
+            except Exception:
+                continue
+            else:
+                metadata = dict_merge(metadata, record)
+        return metadata
 
     @abstractmethod
     def _parse_file(self, path, context=None):

--- a/materials_io/base.py
+++ b/materials_io/base.py
@@ -92,7 +92,8 @@ class BaseParser(ABC):
          and subdirectories of those directories.
 
         Args:
-            paths (str or [str]): Path available for grouping, which could include both files and directories
+            paths (str or [str]): Path available for grouping,
+                which could include both files and directories
             context (dict): Context about the files
         Yields:
             ((str)): Groups of files

--- a/materials_io/base.py
+++ b/materials_io/base.py
@@ -11,8 +11,6 @@ class BaseParser(ABC):
     This class defines the interface for all parsers in MaterialsIO.
     Each new parser must implement the :meth:`parse`, :meth:`version`,
     and :meth:`implementors` functions.
-    The :meth:`is_valid` method should be overrode if fast methods for assessing compatibility
-    (e.g., checking headers) are possible.
     The :meth:`group` method should be overrode to generate smart groups of file (e.g., associating
     the inputs and outputs to the same calculation)
     :meth:`citations` can be used if there are papers that should be cited if the parser is used
@@ -24,6 +22,8 @@ class BaseParser(ABC):
     def parse_directory(self, path, context=None):
         """Run a parser on all appropriate files in a directory
 
+        Skips files that throw exceptions while parsing
+
         Args:
             path (str): Root of directory to parser
             context (dict): An optional data context/configuration dictionary. Default None.
@@ -31,52 +31,25 @@ class BaseParser(ABC):
             ([str], [dict]): Tuple of the group identity and the string
         """
 
-        # Check if is_valid function has been overloaded
-        is_overloaded = self.__class__.is_valid != BaseParser.is_valid
-        logger.debug('Using is_valid' if is_overloaded else 'Attempting to parse every file')
-
         # Run the parsing
         for group in self.group(path, context):
-            if is_overloaded and self.is_valid(group, context):
+            try:
                 yield group, self.parse(group, context)
-            else:
-                # If is_valid, is base implementation, run fill parser anyway
-                try:
-                    yield group, self.parse(group, context)
-                except Exception:
-                    continue
+            except Exception:
+                continue
 
     @abstractmethod
     def parse(self, group, context=None):
         """Extract metadata from a group of files
 
         Arguments:
-            group (list of str):  A list of one or more files to parse as a unit.
+            group (list of str):  A list of one or more files that describe the same object
             context (dict): An optional data context/configuration dictionary. Default None.
 
         Returns:
             (list of dict): The parsed results, in JSON-serializable format.
         """
         pass
-
-    def is_valid(self, group, context=None):
-        """Determine whether a group of files is compatible with this parser
-
-        Arguments:
-            group (list of str):  A list of one or more files to parse as a unit.
-            context (dict): An optional data context/configuration dictionary. Default None.
-
-        Returns:
-            (bool): Whether the group can be parsed by the parser
-        """
-        try:
-            res = self.parse(group, context=context)
-            if not res:
-                raise ValueError
-        except Exception:
-            return False
-        else:
-            return True
 
     def group(self, root, context=None):
         """Identify sets files in a directory that are related to each other
@@ -85,7 +58,7 @@ class BaseParser(ABC):
             root (str): Path to a directory
             context (dict): An optional data context/configuration dictionary. Default None.
         Yields:
-            (list of str): Groups of files
+            ([str]): Groups of files
         """
 
         for path, dirs, files in os.walk(root):

--- a/materials_io/base.py
+++ b/materials_io/base.py
@@ -44,9 +44,8 @@ class BaseParser(ABC):
     def parse_as_unit(self, files):
         """Parse a group of files and merge their metadata
 
-        Used if each file in a group must be parsed separately, but should still only produce one
-        record. For example, if a directory contains separate files from
-        different imaging techniques.
+        Used if each file in a group are parsed separately, but the resultant metadata
+        should be combined after parsing.
 
         Args:
             files ([str]): List of files to parse
@@ -70,22 +69,25 @@ class BaseParser(ABC):
     def parse(self, group, context=None):
         """Extract metadata from a group of files
 
+        A group of files is a set of 1 or more files that describe the same object, and will be
+        be used together to create s single summary record.
+
         Arguments:
             group (list of str):  A list of one or more files that should be parsed together
-            context (dict): An optional data context/configuration dictionary. Default None.
+            context (dict): An optional data context/configuration dictionary
 
         Returns:
             (dict): The parsed results, in JSON-serializable format.
         """
 
     def group(self, root, context=None):
-        """Identify sets files in a directory that are related to each other
+        """Identify sets files in a directory that should be parsed together
 
         Args:
             root (str): Path to a directory
-            context (dict): An optional data context/configuration dictionary. Default None.
+            context (dict): An optional data context/configuration dictionary. 
         Yields:
-            ([str]): Groups of files
+            ((str)): Groups of files
         """
 
         for path, dirs, files in os.walk(root):

--- a/materials_io/base.py
+++ b/materials_io/base.py
@@ -78,9 +78,7 @@ class BaseParser(ABC):
         for group in self.group(files):
             try:
                 record = self.parse(group)
-                print(record)
             except Exception as exc:
-                raise exc
                 continue
             metadata = dict_merge(metadata, record)
         return metadata

--- a/materials_io/base.py
+++ b/materials_io/base.py
@@ -77,7 +77,6 @@ class BaseParser(ABC):
         Returns:
             (dict): The parsed results, in JSON-serializable format.
         """
-        pass
 
     def group(self, root, context=None):
         """Identify sets files in a directory that are related to each other
@@ -113,7 +112,6 @@ class BaseParser(ABC):
                 keys like "email" or "institution" (e.g., {"name": "Anubhav
                 Jain", "email": "ajain@lbl.gov", "institution": "LBNL"}).
         """
-        pass
 
     @abstractmethod
     def version(self):
@@ -122,7 +120,6 @@ class BaseParser(ABC):
         Returns:
             (str): Version of the parser
         """
-        pass
 
     @property
     def schema(self) -> dict:

--- a/materials_io/base.py
+++ b/materials_io/base.py
@@ -78,7 +78,7 @@ class BaseParser(ABC):
         for group in self.group(files):
             try:
                 record = self.parse(group)
-            except Exception as exc:
+            except Exception:
                 continue
             metadata = dict_merge(metadata, record)
         return metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ sphinx_rtd_theme>=0.4.2
 hyperspy>=1.4.1
 pymatgen>=2018.11.30
 ase>=3.16.3b1
-mdf_toolbox>=0.4.0
+mdf_toolbox>=0.4.2
 python-magic>=0.4.15

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     name="materials_io",
     version=version,
     packages=find_packages(include=['materials_io']) + ['materials_io.schemas'],
-    install_requires=['mdf_toolbox>=0.4.0', 'stevedore>=1.28.0'],
+    install_requires=['mdf_toolbox>=0.4.2', 'stevedore>=1.28.0'],
     extras_require={
         'electron_microscopy': ['hyperspy>=1.4.1'],
         'image': ['Pillow>=5.1.0'],

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,4 @@
-from materials_io.base import BaseParser
+from materials_io.base import BaseParser, BaseSingleFileParser
 from glob import glob
 import pytest
 import os
@@ -8,6 +8,18 @@ class FakeParser(BaseParser):
 
     def parse(self, group, context=None):
         return [{}] * len(group)
+
+    def implementors(self):
+        return ['Logan Ward']
+
+    def version(self):
+        return '0.0.0'
+
+
+class FakeSingleParser(BaseSingleFileParser):
+
+    def _parse_file(self, path, context=None):
+        return {}
 
     def implementors(self):
         return ['Logan Ward']
@@ -43,3 +55,12 @@ def test_parse_dir(caplog, parser, directory, my_files):
 
 def test_citations(parser):
     assert parser.citations() == []
+
+
+def test_single_file():
+    parser = FakeSingleParser()
+    assert parser.parse('/fake/file') == {}  # Handle non-standard but sensible inputs
+    assert parser.parse(['/fake/file']) == {}
+    with pytest.raises(ValueError):
+        parser.parse(['/fake/file.in', '/fake/file.out'])
+

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,12 +17,6 @@ class FakeParser(BaseParser):
         return '0.0.0'
 
 
-class FakeParserWithIsValid(FakeParser):
-
-    def is_valid(self, group, context=None):
-        return True
-
-
 @pytest.fixture
 def directory():
     return os.path.dirname(__file__)
@@ -45,17 +39,7 @@ def test_group(parser, directory, my_files):
 
 
 def test_parse_dir(caplog, parser, directory, my_files):
-    with caplog.at_level(logging.DEBUG):
-        # Testing with the default is_valid
-        assert len(list(parser.parse_directory(directory))) == len(my_files)
-        assert 'Attempting to parse every file' in caplog.records[-1].msg
-
-        assert len(list(FakeParserWithIsValid().parse_directory(directory))) == len(my_files)
-        assert 'Using is_valid' in caplog.records[-1].msg
-
-
-def test_is_valid(parser, my_files):
-    assert parser.is_valid(my_files)  # By default
+    assert len(list(parser.parse_directory(directory))) == len(my_files)
 
 
 def test_citations(parser):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -45,7 +45,7 @@ def my_files(directory):
 
 
 def test_group(parser, directory, my_files):
-    groups = set(parser.group(directory))
+    groups = set(parser.group(my_files))
     assert set(groups) == set(zip(my_files))  # Each file own group
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -7,7 +7,7 @@ import os
 class FakeParser(BaseParser):
 
     def parse(self, group, context=None):
-        return [{}] * len(group)
+        return {'group': list(group)}
 
     def implementors(self):
         return ['Logan Ward']
@@ -46,7 +46,7 @@ def my_files(directory):
 
 def test_group(parser, directory, my_files):
     groups = set(parser.group(my_files))
-    assert set(groups) == set(zip(my_files))  # Each file own group
+    assert groups == set(zip(my_files))  # Each file own group
 
 
 def test_parse_dir(caplog, parser, directory, my_files):
@@ -57,14 +57,19 @@ def test_citations(parser):
     assert parser.citations() == []
 
 
-def test_single_file():
+def test_single_file(directory):
     parser = FakeSingleParser()
-    assert parser.parse('/fake/file') == {'dirname': '/fake'}  # Handle sensibly incorrect inputs
-    assert parser.parse(['/fake/file']) == {'dirname': '/fake'}
+    assert parser.parse(__file__) == {'dirname': directory}  # Handle sensibly incorrect inputs
+    assert parser.parse([__file__]) == {'dirname': directory}
     with pytest.raises(ValueError):
         parser.parse(['/fake/file.in', '/fake/file.out'])
 
 
-def test_parse_as_unit():
-    parser = FakeSingleParser()
-    assert parser.parse_as_unit(['/fake/file', '/fake/file2']) == {'dirname': '/fake'}
+def test_parse_as_unit(directory):
+    parser = FakeParser()
+    file_relation = [
+        os.path.join(directory, "data/electron_microscopy/test-EDS_spectrum.dm3"),
+        os.path.join(directory, "data/electron_microscopy/test-1.dm4")
+    ]
+    correct_unit = {"group": file_relation}
+    assert parser.parse_as_unit(file_relation) == correct_unit

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,5 @@
 from materials_io.base import BaseParser
 from glob import glob
-import logging
 import pytest
 import os
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -63,4 +63,3 @@ def test_single_file():
     assert parser.parse(['/fake/file']) == {}
     with pytest.raises(ValueError):
         parser.parse(['/fake/file.in', '/fake/file.out'])
-

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -19,7 +19,7 @@ class FakeParser(BaseParser):
 class FakeSingleParser(BaseSingleFileParser):
 
     def _parse_file(self, path, context=None):
-        return {}
+        return {'dirname': os.path.dirname(path)}
 
     def implementors(self):
         return ['Logan Ward']
@@ -59,7 +59,12 @@ def test_citations(parser):
 
 def test_single_file():
     parser = FakeSingleParser()
-    assert parser.parse('/fake/file') == {}  # Handle non-standard but sensible inputs
-    assert parser.parse(['/fake/file']) == {}
+    assert parser.parse('/fake/file') == {'dirname': '/fake'}  # Handle sensibly incorrect inputs
+    assert parser.parse(['/fake/file']) == {'dirname': '/fake'}
     with pytest.raises(ValueError):
         parser.parse(['/fake/file.in', '/fake/file.out'])
+
+
+def test_parse_as_unit():
+    parser = FakeSingleParser()
+    assert parser.parse_as_unit(['/fake/file', '/fake/file2']) == {'dirname': '/fake'}

--- a/tests/test_crystal_structure.py
+++ b/tests/test_crystal_structure.py
@@ -15,11 +15,7 @@ def parser():
 
 
 def test_cif(parser, cif):
-    output = parser.parse([cif])
-
-    # Make sure the output has a single value
-    assert len(output) == 1
-    output = output[0]
+    output = parser.parse(cif)
 
     # Check the volume and number of atoms, which is a float
     assert isclose(output['crystal_structure']['volume'], 101836.44086588411)

--- a/tests/test_electron_microscopy.py
+++ b/tests/test_electron_microscopy.py
@@ -27,17 +27,17 @@ def parser():
     return ElectronMicroscopyParser()
 
 
-# TODO (lw): Our extractor does not actually get anything from these files
+# TODO (lw): Our parser does not actually get anything from these files
 def test_dm3(parser, dm3):
-    assert parser.parse([dm3]) == [{}]
+    assert parser.parse([dm3]) == {}
 
 
 def test_dm4(parser, dm4):
-    assert parser.parse([dm4]) == [{}]
+    assert parser.parse([dm4]) == {}
 
 
 def test_eds(parser, eds):
-    assert parser.parse([eds]) == [{'electron_microscopy': {'beam_energy': 200.0,
-                                                            'magnification': 320000.0,
-                                                            'image_mode': 'STEM',
-                                                            'detector': 'EDS'}}]
+    assert parser.parse([eds]) == {'electron_microscopy': {'beam_energy': 200.0,
+                                                           'magnification': 320000.0,
+                                                           'image_mode': 'STEM',
+                                                           'detector': 'EDS'}}

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -5,9 +5,9 @@ import os
 def test_file():
     my_file = os.path.join(os.path.dirname(__file__), 'data', 'image', 'dog2.jpeg')
     parser = GenericFileParser(store_path=True, compute_hash=True)
-    assert parser.parse([my_file]) == [
-        {'mime_type': 'image/jpeg', 'length': 269360, 'filename': 'dog2.jpeg',
-         'path': my_file,
-         'hash': '1f47ed450ad23e92caf1a0e5307e2af9b13edcd7735ac9685c9f21c9faec62'
-                 'cb95892e890a73480b06189ed5b842d8b265c5e47cc6cf279d281270211cff8f90'}]
+    assert parser.parse([my_file]) == {
+        'mime_type': 'image/jpeg', 'length': 269360, 'filename': 'dog2.jpeg',
+        'path': my_file,
+        'hash': '1f47ed450ad23e92caf1a0e5307e2af9b13edcd7735ac9685c9f21c9faec62'
+                'cb95892e890a73480b06189ed5b842d8b265c5e47cc6cf279d281270211cff8f90'}
     assert isinstance(parser.schema, dict)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -11,5 +11,5 @@ def test_image():
 
 def test_parse(test_image):
     p = ImageParser()
-    assert (p.parse([test_image]) == [{'image': {'format': 'JPEG', 'height': 1000,
-                                                 'megapixels': 1.91, 'width': 1910}}])
+    assert (p.parse([test_image]) == {'image': {'format': 'JPEG', 'height': 1000,
+                                                'megapixels': 1.91, 'width': 1910}})


### PR DESCRIPTION
Makes several changes discussed by @jgaff and I today:

- Removes `is_valid`, advises filtering logic to be moved to `group`
- Changes recommendations on where to throw exceptions (closes #11) 
- Adds `parse_as_unit` function to automatically merge metadata from multiple files
- Clarified documentation about groups (fixes #9 )