### PR TITLE
Revise grouping

### DIFF
--- a/docs/source/contributor-guide.rst
+++ b/docs/source/contributor-guide.rst
@@ -66,10 +66,16 @@ We also have a recommendations for the parser behavior:
 Implementing ``group``
 ----------------------
 
-The ``group`` operation finds all sets of files in a user-provided of paths list that should be parsed together.
+The ``group`` operation finds all sets of files in a user-provided list files and directories that should be parsed together.
 Implementing ``group`` is optional.
 Implementing a new ``group`` method is required only when the default behavior of "each file is its own group"
 (i.e., the parser only treats files individually) is incorrect.
+
+The ``group`` operation should not require access to the content of the files or directories
+to determine groupings.
+Being able to determine file groups via only file names improves performance
+and allows for determining groups of parsable files without needing to download
+them from remote systems.
 
 Files are allowed to appear in more than one group,
 but we recommend generating only the largest valid group of files to minimize the same metadata being generated multiple times.
@@ -81,6 +87,7 @@ without consideration to what other information makes the files related (e.g., b
 
 Another appropriate use of the ``group`` operation is to filter out files which are very unlikely to parse correctly.
 For example, a PDF parser could identify only files with a ".pdf" extension.
+However, we recommend using filtering sparing to ensure no files are missed.
 
 Implementing ``citations`` and ``implementors``
 -----------------------------------------------

--- a/docs/source/goals.rst
+++ b/docs/source/goals.rst
@@ -33,7 +33,7 @@ There are several questions that are specifically out-of-scope for MaterialsIO:
 1. *How do I get access to files that I want to parse?*
     MaterialsIO does not solve the data transfer problem
 2. *How can I parse large numbers of files reliably?*
-    MaterialsIO is not a distributed workflow engine, but is designed to intregrate
+    MaterialsIO is not a distributed workflow engine, but is designed to integrate
     with one for extracting metadata from large filesystems.
 3. *How can I translate data into the schema needed for my application?*
     The goal of MaterialsIO is to go from opaque to well-documented formats.

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -130,9 +130,10 @@ Grouping Files
 ++++++++++++++
 
 Parsers also provide the ability to quickly find groups of associated files: ``group``.
-The ``group`` operation takes path or list of paths as input and generates candidate groups of files::
+The ``group`` operation takes path or list of files and, optionally, directories and generates
+a list of files that should be treated together when parsing::
 
-    parser.group('/data/directory')
+    parser.group(['input.file', 'output.file', 'unrelated']) # -> [('input.file', 'output.file'), ('unrelated',)]
 
 Parsing Entire Directories
 ++++++++++++++++++++++++++
@@ -141,7 +142,7 @@ Parsing Entire Directories
 
     metadata = list(parser.parse_directory('.'))
 
-``parse_directory`` is a generator function, so we use ``list`` to turn the output into a list format.
+``parse_directory`` is a generator function, so we use ``list`` here to turn the output into a list format.
 
 Attribution Functions
 +++++++++++++++++++++

--- a/materials_io/base.py
+++ b/materials_io/base.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import List, Iterator, Tuple, Iterable, Union
 from abc import ABC, abstractmethod
 import logging

--- a/materials_io/csv.py
+++ b/materials_io/csv.py
@@ -1,7 +1,7 @@
 from materials_io.base import BaseSingleFileParser
 from tableschema.exceptions import CastError
 from tableschema import Table
-from typing import List, Union, Tuple, Iterable, Iterator
+from typing import List
 import logging
 
 logger = logging.getLogger(__name__)

--- a/materials_io/csv.py
+++ b/materials_io/csv.py
@@ -29,12 +29,6 @@ class CSVParser(BaseSingleFileParser):
         self.return_records = return_records
         self.infer_kwargs = kwargs
 
-    def group(self, paths: Union[str, Iterable[str]],
-              context: dict = None) -> Iterator[Tuple[str, ...]]:
-        for path in super().group(paths, context):
-            if path[0].lower().endswith('.csv'):
-                yield path
-
     def _parse_file(self, path: str, context=None):
         # Set the default value
         if context is None:

--- a/materials_io/dft.py
+++ b/materials_io/dft.py
@@ -3,7 +3,6 @@ from materials_io.utils.grouping import preprocess_paths, group_by_postfix
 from materials_io.base import BaseParser
 from dfttopif import files_to_pif
 from operator import itemgetter
-from glob import glob
 import itertools
 import os
 

--- a/materials_io/utils/grouping.py
+++ b/materials_io/utils/grouping.py
@@ -25,7 +25,7 @@ def preprocess_paths(paths: Union[str, Path, List[str], List[Path]]) -> List[str
     return [os.path.abspath(os.path.expanduser(f)) for f in paths]
 
 
-def group_by_postfix(files: List[str], vocabulary: List[str]) -> Iterable[Tuple[str, ...]]:
+def group_by_postfix(files: Iterable[str], vocabulary: List[str]) -> Iterable[Tuple[str, ...]]:
     """Group files that have a common ending
 
     Finds all filenames that begin with a prefixes from a

--- a/materials_io/utils/interface.py
+++ b/materials_io/utils/interface.py
@@ -164,6 +164,7 @@ def run_all_parsers(directory: str, global_context=None,
         adapter_map = {}
     elif adapter_map == 'match':
         adapters = get_available_adapters()
+        print(get_available_adapters())
         adapter_map = dict((x, x) for x in parsers if x in adapters)
     elif not isinstance(adapter_map, dict):
         raise ValueError('Adapter map must be a dict, None, or `matching`')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,9 +40,14 @@ def test_run_all_parsers():
     output_matching = list(run_all_parsers(path, adapter_map={'file': 'noop'},
                                            default_adapter='serialize'))
     assert all(isinstance(x.metadata, str if x.parser != 'file' else dict) for x in output_matching)
-    output_matching = list(run_all_parsers(path, adapter_map='match',
-                                           default_adapter='serialize'))
-    assert all(isinstance(x.metadata, str if x.parser != 'noop' else dict) for x in output_matching)
+
+    # This matching test fails if we have other packages with adapters on the system
+    adapters = set(get_available_adapters().keys())
+    if adapters == {'noop', 'serialize'}:
+        output_matching = list(run_all_parsers(path, adapter_map='match',
+                                               default_adapter='serialize'))
+        assert all(isinstance(x.metadata, str if x.parser != 'noop' else dict)
+                   for x in output_matching)
 
     # Test the error case
     with pytest.raises(ValueError):


### PR DESCRIPTION
Changes the `group` operation to not require filesystem access in order to determine groups of files. 

These changes are made to enable an interface with XtractHub, which would prefer to determine file groupings before having to download the data from a remote server. 
Determining groups beforehand means all of the data need not be downloaded at once. 